### PR TITLE
Update SetBackupState to match Windows API function

### DIFF
--- a/IVssBackupComponents.go
+++ b/IVssBackupComponents.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package vss
@@ -202,8 +203,19 @@ func (vss *IVssBackupComponents) SetContext(context VssContext) error {
 }
 
 // The SetBackupState method defines an overall configuration for a backup operation.
-func (vss *IVssBackupComponents) SetBackupState(state VssBackup) error {
-	code, _, _ := syscall.Syscall6(vss.getVTable().setBackupState, 4, uintptr(unsafe.Pointer(vss)), 0, 0, uintptr(state), 0, 0)
+func (vss *IVssBackupComponents) SetBackupState(selectComponents bool, backupBootableState bool, state VssBackup, partialFileSupport bool) error {
+	var bSelectComponents, bBackupBootableState, bPartialFileSupport uint32
+	if selectComponents {
+		bSelectComponents = 1
+	}
+	if backupBootableState {
+		bBackupBootableState = 1
+	}
+	if partialFileSupport {
+		bPartialFileSupport = 1
+	}
+
+	code, _, _ := syscall.Syscall6(vss.getVTable().setBackupState, 4, uintptr(unsafe.Pointer(vss)), uintptr(bSelectComponents), uintptr(bBackupBootableState), uintptr(state), uintptr(bPartialFileSupport), 0)
 	return CreateVSSError("IVssBackupComponents.SetBackupState", code)
 }
 

--- a/vss_windows.go
+++ b/vss_windows.go
@@ -31,7 +31,7 @@ func (v *Snapshotter) CreateSnapshot(drive string, timeout int, force bool) (*Sn
 		return nil, err
 	}
 
-	if err := vssBackupComponent.SetBackupState(VSS_BT_COPY); err != nil {
+	if err := vssBackupComponent.SetBackupState(false, false, VSS_BT_COPY, false); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR updates SetBackupState implementation to make flags `selectComponents`, `backupBootableState` and `partialFileSupport` configurable and match Windows API function definition - [SetBackupState](https://learn.microsoft.com/en-us/windows/win32/api/vsbackup/nf-vsbackup-ivssbackupcomponents-setbackupstate).

@JeromeHadorn thanks for the package, what do you think about this change? Potentially it can be a breaking one for those using `IVssBackupComponents` directly instead of `Snapshotter`, but on the other hand, this is the correct implementation in terms of Windows API definitions.